### PR TITLE
feat: options on POST /organizations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "apisuite-be",
-  "version": "2.26.1",
+  "version": "2.34.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/routes/organization.docs.js
+++ b/routes/organization.docs.js
@@ -40,6 +40,18 @@
  *           description: Only available to admins
  *         address:
  *           $ref: "#/components/schemas/address"
+ *
+ *     CreateOrganization:
+ *       allOf:
+ *         - $ref: "#/components/schemas/address"
+ *         - type: object
+ *           properties:
+ *             options:
+ *               type: object
+ *               properties:
+ *                 selfAssignNewOrganization:
+ *                   type: boolean
+ *                   default: true
  */
 
 /**

--- a/routes/organization.js
+++ b/routes/organization.js
@@ -187,7 +187,7 @@ router.getAsync('/:orgId',
  *       content:
  *         application/json:
  *           schema:
- *             $ref: "#/components/schemas/Organization"
+ *             $ref: "#/components/schemas/CreateOrganization"
  *     security:
  *       - cookieAuth: []
  *     responses:

--- a/routes/validation_schemas/organization.schema.js
+++ b/routes/validation_schemas/organization.schema.js
@@ -26,6 +26,12 @@ const organizationSchema = (create) => {
     }).optional(),
   }
 
+  if (create) {
+    baseSchema.options = Joi.object({
+      selfAssignNewOrganization: Joi.boolean().optional(),
+    }).optional()
+  }
+
   baseSchema.name = create
     ? Joi.string().required()
     : Joi.string().optional()


### PR DESCRIPTION
Added an (optional) `options` object to the payload of POST /organizations.
```
{
    "name": "ACME",
    "options": {
        "selfAssignNewOrganization": false
    }
}
```

This object accepts the `selfAssignNewOrganization` (the only one for now) that determines if the user creating the organization should be automatically assigned to it or not. Not providing an options object or this property should default to `true` as if the property was there, in order to maintain backwards compatibility with the current behaviour.