### PR TITLE
docs: fixed docs for translations

### DIFF
--- a/routes/translations.js
+++ b/routes/translations.js
@@ -6,7 +6,7 @@ const controllers = require('../controllers')
 
 /**
  * @openapi
- * /translations/{locale}:
+ * /translations/{locale}/{extension}:
  *   get:
  *     summary: Get translations object for a locale
  *     tags: [Translations]
@@ -18,7 +18,7 @@ const controllers = require('../controllers')
  *         schema:
  *           type: string
  *       - name: extension
- *         description: extension of each language (en-US, pt-PT, etc)
+ *         description: extension of each language (core, etc)
  *         required: true
  *         in: path
  *         schema:


### PR DESCRIPTION
The docs for translations is out-of-date based with the latest changes. The `extension` parameter was not documented in the example request.